### PR TITLE
remove node-local interface

### DIFF
--- a/cmd/k-vswitchd/main.go
+++ b/cmd/k-vswitchd/main.go
@@ -52,7 +52,6 @@ import (
 const (
 	cniConfigPath           = "/etc/cni/net.d/10-k-vswitch.json"
 	bridgeName              = "k-vswitch0"
-	nodeLocalPort           = "node-local"
 	clusterWidePort         = "cluster-wide"
 	overlayPort             = "overlay0"
 	defaultControllerTarget = "tcp:127.0.0.1:6653"
@@ -115,15 +114,9 @@ func main() {
 	clusterCIDR := vswitchConfig.Spec.ClusterCIDR
 	serviceCIDR := vswitchConfig.Spec.ServiceCIDR
 
-	err = setupBridgeIfNotExists()
+	err = setupOVSBridgeIfNotExists()
 	if err != nil {
 		klog.Errorf("failed to setup OVS bridge: %v", err)
-		os.Exit(1)
-	}
-
-	err = setupNodeLocalInternalPort()
-	if err != nil {
-		klog.Errorf("failed to setup node-local port: %v", err)
 		os.Exit(1)
 	}
 
@@ -139,7 +132,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	nodeLocalLink, err := netlink.LinkByName(nodeLocalPort)
+	bridgeLink, err := netlink.LinkByName(bridgeName)
 	if err != nil {
 		klog.Errorf("failed to get bridge %q, err: %v", bridgeName, err)
 		os.Exit(1)
@@ -157,9 +150,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := netlink.AddrReplace(nodeLocalLink, addr); err != nil {
+	if err := netlink.AddrReplace(bridgeLink, addr); err != nil {
 		klog.Errorf("could not add local pod cidr %q to port %q, err: %v",
-			podCIDR, nodeLocalLink, err)
+			podCIDR, bridgeLink, err)
 		os.Exit(1)
 	}
 
@@ -195,9 +188,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	nodeLocalInterface, err := net.InterfaceByName(nodeLocalPort)
+	ovsBridgeInterface, err := net.InterfaceByName(bridgeName)
 	if err != nil {
-		klog.Errorf("error getting interface %q: err: %v", nodeLocalPort, err)
+		klog.Errorf("error getting interface %q: err: %v", bridgeName, err)
 		os.Exit(1)
 	}
 
@@ -232,7 +225,7 @@ func main() {
 
 	c, err := openflow.NewController(connectionManager, podInformer,
 		nsInformer, netPolInformer, vswitchInformer, bridgeName,
-		nodeLocalInterface.HardwareAddr.String(),
+		ovsBridgeInterface.HardwareAddr.String(),
 		clusterWideInterface.HardwareAddr.String(),
 		curNode.Name, podCIDR, clusterCIDR)
 	if err != nil {
@@ -342,7 +335,7 @@ func installCNIConf(podCIDR string) error {
 	return ioutil.WriteFile(cniConfigPath, []byte(conf), 0644)
 }
 
-func setupBridgeIfNotExists() error {
+func setupOVSBridgeIfNotExists() error {
 	command := []string{
 		"--may-exist", "add-br", bridgeName,
 	}
@@ -360,29 +353,6 @@ func setupBridgeIfNotExists() error {
 
 	if err := netlink.LinkSetUp(br); err != nil {
 		return fmt.Errorf("failed to bring bridge %q up: %v", bridgeName, err)
-	}
-
-	return nil
-}
-
-func setupNodeLocalInternalPort() error {
-	command := []string{
-		"--may-exist", "add-port", bridgeName, nodeLocalPort,
-		"--", "set", "Interface", nodeLocalPort, "type=internal",
-	}
-
-	out, err := exec.Command("ovs-vsctl", command...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to setup node-local port, err: %v, output: %q", err, out)
-	}
-
-	nodeLocal, err := netlink.LinkByName(nodeLocalPort)
-	if err != nil {
-		return fmt.Errorf("could not lookup %q: %v", nodeLocalPort, err)
-	}
-
-	if err := netlink.LinkSetUp(nodeLocal); err != nil {
-		return fmt.Errorf("failed to bring bridge %q up: %v", nodeLocalPort, err)
 	}
 
 	return nil
@@ -460,19 +430,19 @@ func setupBridgeForwarding(podCIDR, clusterCIDR, serviceCIDR string) error {
 		return err
 	}
 
-	rules := []string{"-o", nodeLocalPort, "-j", "ACCEPT"}
+	rules := []string{"-o", bridgeName, "-j", "ACCEPT"}
 	err = ipt.AppendUnique("filter", "FORWARD", rules...)
 	if err != nil {
 		return err
 	}
 
-	rules = []string{"-i", nodeLocalPort, "-j", "ACCEPT"}
+	rules = []string{"-i", bridgeName, "-j", "ACCEPT"}
 	err = ipt.AppendUnique("filter", "FORWARD", rules...)
 	if err != nil {
 		return err
 	}
 
-	rules = []string{"-s", podCIDR, "!", "-o", nodeLocalPort, "-j", "MASQUERADE"}
+	rules = []string{"-s", podCIDR, "!", "-o", bridgeName, "-j", "MASQUERADE"}
 	err = ipt.AppendUnique("nat", "POSTROUTING", rules...)
 	if err != nil {
 		return err

--- a/controllers/openflow/controller.go
+++ b/controllers/openflow/controller.go
@@ -39,7 +39,6 @@ import (
 )
 
 const (
-	nodeLocalPort   = "node-local"
 	clusterWidePort = "cluster-wide"
 	overlayPort     = "overlay0"
 )
@@ -56,12 +55,11 @@ type controller struct {
 	nodeName       string
 	bridgeName     string
 	gatewayIP      string
-	nodeLocalMAC   string
+	bridgeMAC      string
 	clusterWideMAC string
 	podCIDR        string
 	clusterCIDR    string
 
-	nodeLocalOFPort   int
 	clusterWideOFPort int
 	overlayOFPort     int
 
@@ -81,7 +79,7 @@ func NewController(connManager connectionManager,
 	namespaceInformer v1informer.NamespaceInformer,
 	netPolInformer netinformer.NetworkPolicyInformer,
 	kvswitchInformer kvswitchinformers.VSwitchConfigInformer,
-	bridgeName, nodeLocalMAC, clusterWideMAC, nodeName,
+	bridgeName, bridgeMAC, clusterWideMAC, nodeName,
 	podCIDR, clusterCIDR string) (*controller, error) {
 
 	_, podIPNet, err := net.ParseCIDR(podCIDR)
@@ -89,11 +87,6 @@ func NewController(connManager connectionManager,
 		return nil, err
 	}
 	gatewayIP := ip.NextIP(podIPNet.IP.Mask(podIPNet.Mask)).String()
-
-	nodeLocalOFPort, err := ofPortFromName(nodeLocalPort)
-	if err != nil {
-		return nil, err
-	}
 
 	clusterWideOFPort, err := ofPortFromName(clusterWidePort)
 	if err != nil {
@@ -110,11 +103,10 @@ func NewController(connManager connectionManager,
 		nodeName:          nodeName,
 		bridgeName:        bridgeName,
 		gatewayIP:         gatewayIP,
-		nodeLocalMAC:      nodeLocalMAC,
+		bridgeMAC:         bridgeMAC,
 		clusterWideMAC:    clusterWideMAC,
 		podCIDR:           podCIDR,
 		clusterCIDR:       clusterCIDR,
-		nodeLocalOFPort:   nodeLocalOFPort,
 		clusterWideOFPort: clusterWideOFPort,
 		overlayOFPort:     overlayOFPort,
 		flows:             flows.NewFlowsBuffer(),

--- a/flows/flows.go
+++ b/flows/flows.go
@@ -43,8 +43,9 @@ type Flow struct {
 	output    int
 	resubmit  int
 	drop      bool
-
-	raw string
+	local     bool
+	
+	raw       string
 }
 
 func NewFlow() *Flow {
@@ -117,6 +118,10 @@ func (f *Flow) String() string {
 		actionSet = append(actionSet, "drop")
 	}
 
+	if f.local {
+		actionSet = append(actionSet, "local")
+	}
+
 	actions := fmt.Sprintf("actions=%s", strings.Join(actionSet, ","))
 
 	flow = fmt.Sprintf("%s %s", flow, actions)
@@ -182,32 +187,39 @@ func (f *Flow) WithUDPDestPort(dstPort int) *Flow {
 	return f
 }
 
-func (f *Flow) WithModDlDest(dstMac string) *Flow {
+func (f *Flow) WithRaw(raw string) *Flow {
+	f.raw = raw
+	return f
+}
+
+// Actions that can be applied for a flow
+
+func (f *Flow) WithActionModDlDest(dstMac string) *Flow {
 	f.modDlDest = dstMac
 	return f
 }
 
-func (f *Flow) WithTunnelDest(tunDst string) *Flow {
+func (f *Flow) WithActionTunnelDest(tunDst string) *Flow {
 	f.tunDest = tunDst
 	return f
 }
 
-func (f *Flow) WithOutputPort(output int) *Flow {
+func (f *Flow) WithActionOutputPort(output int) *Flow {
 	f.output = output
 	return f
 }
 
-func (f *Flow) WithDrop() *Flow {
+func (f *Flow) WithActionDrop() *Flow {
 	f.drop = true
 	return f
 }
 
-func (f *Flow) WithResubmit(table int) *Flow {
+func (f *Flow) WithActionResubmit(table int) *Flow {
 	f.resubmit = table
 	return f
 }
 
-func (f *Flow) WithRaw(raw string) *Flow {
-	f.raw = raw
+func (f *Flow) WithActionLocal() *Flow {
+	f.local = true
 	return f
 }


### PR DESCRIPTION
**Why**
Previously, an additional interface was added as a work-around for ARP to work. This commit, removes this interface and directly uses the generated OVS bridge as a default gateway relying on the arp-responder (#10) for arp traffic.

**Issue Fix**
#4 

cc @andrewsykim 